### PR TITLE
Update build.rs to support iOS SDK 18.1

### DIFF
--- a/pqcrypto-internals/build.rs
+++ b/pqcrypto-internals/build.rs
@@ -58,7 +58,7 @@ fn main() {
         println!("cargo:rustc-link-lib=keccak4x")
     } else if target_arch == "aarch64" && target_env != "msvc" {
         builder
-            .flag("-march=armv8-a")
+            .flag("-march=armv8-a+sha3")
             .file(cfiledir.join("keccak2x").join("fips202x2.c"))
             .file(cfiledir.join("keccak2x").join("feat.S"))
             .compile("keccak2x");


### PR DESCRIPTION
I was still experiencing this same error even with version 0.2.7. I noticed the OP in https://github.com/rustpq/pqcrypto/issues/68 was using iOS SDK 17.2. I have since updated to Xcode 16 which is at iOS SDK 18.1 and the build flag did not fix it. However, through some searching I found that updating the build flag to `-march=armv8-a+sha3` seems to work.

Unfortunately, I'm not using the library directly but it is an indirect dependency of Flutter Rust Bridge (https://github.com/fzyzcjy/flutter_rust_bridge) that I am using to build a Flutter mobile app backed by a custom Rust library. I'm not sure if my fix is universal or is just appropriate for my specific use case.